### PR TITLE
Implement reservation update API

### DIFF
--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import prisma from "@/lib/prisma";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { id } = req.query as { id: string };
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // Only allow modifying the user's own reservation
+  const reservation = await prisma.reservation.findUnique({ where: { id } });
+  if (!reservation || reservation.userId !== session.user.id) {
+    return res.status(404).json({ error: "Reservation not found" });
+  }
+
+  if (req.method === "PUT") {
+    const { date } = req.body as { date?: string };
+    if (!date) {
+      return res.status(400).json({ error: "Missing date" });
+    }
+    await prisma.reservation.update({
+      where: { id },
+      data: { date: new Date(date) },
+    });
+    return res.status(200).json({ ok: true });
+  }
+
+  if (req.method === "DELETE") {
+    await prisma.reservation.delete({ where: { id } });
+    return res.status(200).json({ ok: true });
+  }
+
+  res.setHeader("Allow", ["PUT", "DELETE"]);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}


### PR DESCRIPTION
## Summary
- allow editing or deleting reservations via new endpoint

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a3a3b0ec48332953a9b251d7692ba