### PR TITLE
Improve dashboard UX

### DIFF
--- a/src/components/dashboard/HistorySection.tsx
+++ b/src/components/dashboard/HistorySection.tsx
@@ -8,10 +8,11 @@ import {
   Button,
   OverlayTrigger,
   Tooltip,
+  Toast,
 } from "react-bootstrap";
 import Calendar from "react-calendar";
 import "react-calendar/dist/Calendar.css";
-import { FaEdit } from "react-icons/fa";
+import { FaEdit, FaTrash } from "react-icons/fa";
 
 interface HistoryItem {
   id: string;
@@ -27,6 +28,8 @@ export default function HistorySection() {
   const [editSlot, setEditSlot] = useState<HistoryItem | null>(null);
   const [newDate, setNewDate] = useState<Date | null>(null);
   const [newHour, setNewHour] = useState<number | null>(null);
+  const [toastMsg, setToastMsg] = useState<string>("");
+  const [showToast, setShowToast] = useState(false);
 
   useEffect(() => {
     fetch("/api/appointments/history")
@@ -63,6 +66,16 @@ export default function HistorySection() {
       )
     );
     setShowModal(false);
+    setToastMsg("Reservación actualizada");
+    setShowToast(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("¿Eliminar esta reservación?")) return;
+    await fetch(`/api/appointments/${id}`, { method: "DELETE" });
+    setRows((cur) => cur.filter((r) => r.id !== id));
+    setToastMsg("Reservación cancelada");
+    setShowToast(true);
   };
 
   if (loading) return <Spinner className="m-5" animation="border" />;
@@ -76,12 +89,13 @@ export default function HistorySection() {
             <th>Terapeuta</th>
             <th>Fecha y hora</th>
             <th>Editar</th>
+            <th>Eliminar</th>
           </tr>
         </thead>
         <tbody>
           {rows.length === 0 ? (
             <tr>
-              <td colSpan={4} className="text-center">
+              <td colSpan={5} className="text-center">
                 — No hay reservaciones —
               </td>
             </tr>
@@ -106,6 +120,11 @@ export default function HistorySection() {
                         <FaEdit size={18} />
                       </Button>
                     </OverlayTrigger>
+                  </td>
+                  <td>
+                    <Button variant="link" onClick={() => handleDelete(r.id)}>
+                      <FaTrash size={18} />
+                    </Button>
                   </td>
                 </tr>
               );
@@ -160,6 +179,15 @@ export default function HistorySection() {
           </Button>
         </Modal.Footer>
       </Modal>
+      <Toast
+        onClose={() => setShowToast(false)}
+        show={showToast}
+        delay={3000}
+        autohide
+        className="position-fixed bottom-0 end-0 m-3"
+      >
+        <Toast.Body>{toastMsg}</Toast.Body>
+      </Toast>
     </>
   );
 }

--- a/src/components/dashboard/PurchasedPackagesSection.tsx
+++ b/src/components/dashboard/PurchasedPackagesSection.tsx
@@ -21,7 +21,13 @@ export default function PurchasedPackagesSection() {
   useEffect(() => {
     fetch("/api/dashboard/packages")
       .then((r) => r.json())
-      .then((data: UserPackageResponse[]) => setPackages(data))
+      .then((data: UserPackageResponse[]) =>
+        setPackages(
+          data.sort(
+            (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+          )
+        )
+      )
       .catch(console.error)
       .finally(() => setLoading(false));
   }, []);
@@ -75,11 +81,13 @@ export default function PurchasedPackagesSection() {
               <Card.Body>
                 <Card.Title>{pkg.pkgName}</Card.Title>
                 <Card.Text>
-                  Sesiones restantes: {pkg.sessionsRemaining}
+                  Comprado: {new Date(pkg.createdAt).toLocaleDateString()}
                 </Card.Text>
                 <Card.Text>
-                  Vence:{" "}
-                  {new Date(pkg.expiresAt).toLocaleDateString()}
+                  Vence: {new Date(pkg.expiresAt).toLocaleDateString()}
+                </Card.Text>
+                <Card.Text>
+                  Sesiones restantes: {pkg.sessionsRemaining}
                 </Card.Text>
                 <Button
                   className="btn-orange"

--- a/src/pages/api/appointments/[id].ts
+++ b/src/pages/api/appointments/[id].ts
@@ -1,0 +1,42 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../auth/[...nextauth]";
+import prisma from "@/lib/prisma";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const { id } = req.query as { id: string };
+  const session = await getServerSession(req, res, authOptions);
+
+  if (!session?.user?.id) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  // Only allow modifying the user's own reservation
+  const reservation = await prisma.reservation.findUnique({ where: { id } });
+  if (!reservation || reservation.userId !== session.user.id) {
+    return res.status(404).json({ error: "Reservation not found" });
+  }
+
+  if (req.method === "PUT") {
+    const { date } = req.body as { date?: string };
+    if (!date) {
+      return res.status(400).json({ error: "Missing date" });
+    }
+    await prisma.reservation.update({
+      where: { id },
+      data: { date: new Date(date) },
+    });
+    return res.status(200).json({ ok: true });
+  }
+
+  if (req.method === "DELETE") {
+    await prisma.reservation.delete({ where: { id } });
+    return res.status(200).json({ ok: true });
+  }
+
+  res.setHeader("Allow", ["PUT", "DELETE"]);
+  return res.status(405).end(`Method ${req.method} Not Allowed`);
+}

--- a/src/pages/api/dashboard/packages.ts
+++ b/src/pages/api/dashboard/packages.ts
@@ -10,6 +10,7 @@ export interface UserPackageResponse {
   priceId: string;
   sessionsRemaining: number;
   expiresAt: string;
+  createdAt: string;
 }
 
 export default async function handler(
@@ -45,6 +46,7 @@ export default async function handler(
       priceId: u.pkg.stripePriceId,
       sessionsRemaining: u.sessionsRemaining,
       expiresAt: exp.toISOString(),
+      createdAt: u.createdAt.toISOString(),
     };
   });
 

--- a/src/pages/success.tsx
+++ b/src/pages/success.tsx
@@ -3,6 +3,7 @@ import { GetServerSideProps } from "next";
 import Stripe from "stripe";
 import Link from "next/link";
 import DashboardLayout from "@/components/DashboardLayout";
+import { Alert } from "react-bootstrap";
 import prisma from "@/lib/prisma";
 
 interface SessionItem {
@@ -123,6 +124,7 @@ export default function Success({ items }: SuccessProps) {
   return (
     <DashboardLayout>
       <div className="text-center py-5">
+        <Alert variant="success">¡Sesión agendada!</Alert>
         <h1>¡Gracias por tu pago!</h1>
         <p>Agrega tus sesiones al calendario:</p>
         <div className="d-flex flex-wrap justify-content-center gap-3 my-4">


### PR DESCRIPTION
## Summary
- show toast notifications when editing or deleting reservations
- order purchased packages and show purchase/expiration dates
- expose `createdAt` in packages API
- display success alert when finishing purchase

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a3a3b0ec48332953a9b251d7692ba