### PR TITLE
Fix Stripe checkout and package IDs

### DIFF
--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -14,7 +14,7 @@ async function main() {
     { id: 'agua_12',        stripePriceId: 'price_1RMBIaFV5ZpZiouC8l6QjW2N',   name: 'Estimulación en agua (12×mes)',              sessions: 12, price: 2500, inscription: 30 },
     { id: 'piso_1',         stripePriceId: 'price_1RJd1jFV5ZpZiouC1xXvllVc',   name: 'Estimulación temprana en piso',              sessions: 1,  price: 500,  inscription: 30 },
     { id: 'piso_4',         stripePriceId: 'price_1RP6S2FV5ZpZiouC6cVpXQsJ',   name: 'Estimulación en piso (4×mes)',               sessions: 4,  price: 1400, inscription: 30 },
-    { id: 'piso_8',         stripePriceId: ' price_1RP6SsFV5ZpZiouCtbg4A7OE',   name: 'Estimulación en piso (8×mes)',               sessions: 8,  price: 2250, inscription: 30 },
+    { id: 'piso_8',         stripePriceId: 'price_1RP6SsFV5ZpZiouCtbg4A7OE',   name: 'Estimulación en piso (8×mes)',               sessions: 8,  price: 2250, inscription: 30 },
     { id: 'piso_12',        stripePriceId: 'price_1RP6TaFV5ZpZiouCoG5G58S3',   name: 'Estimulación en piso (12×mes)',              sessions: 12, price: 2500, inscription: 30 },
     { id: 'fisio_1',        stripePriceId: 'price_1RJd3WFV5ZpZiouC9PDzHjKU',   name: 'Fisioterapia (1 sesión)',                     sessions: 1,  price: 500,  inscription: 30 },
     { id: 'fisio_5',        stripePriceId: 'price_1RP6WwFV5ZpZiouCN3m0luq3',   name: 'Fisioterapia (5 sesiones)',                   sessions: 5,  price: 2000, inscription: 30 },

--- a/src/components/ReservasForm.tsx
+++ b/src/components/ReservasForm.tsx
@@ -85,9 +85,9 @@ export default function ReservasForm() {
   const handleConfirm = async () => {
     const svc = servicios.find((s) => s.slug === servicio)!;
     const stripeBody = {
-      userId: session?.user?.id,
-      lineItems: [{ price: svc.priceId, quantity: 1 }],
+      priceId: svc.priceId,
       metadata: {
+        userId: session?.user?.id ?? "",
         servicio,
         terapeuta,
         date: fecha!.toISOString(),

--- a/src/components/dashboard/PackagesSection.tsx
+++ b/src/components/dashboard/PackagesSection.tsx
@@ -16,7 +16,7 @@ export default function PackagesSection() {
         pathname: "/dashboard",
         query: {
           view: "reservar-paquete",
-          type: pkg.id,
+          pkgKey: pkg.id,
           sessions: pkg.sessions,
           priceId: pkg.priceId,
           title: pkg.title,

--- a/src/components/dashboard/PurchasedPackagesSection.tsx
+++ b/src/components/dashboard/PurchasedPackagesSection.tsx
@@ -41,8 +41,8 @@ export default function PurchasedPackagesSection() {
         pathname: "/dashboard",
         query: {
           view: "reservar-paquete",
-          type: pkg.pkgId,    // coincide con el prop `type` de ReservarPaquete
-          sessions: 1,        // siempre 1 sesión
+          pkgKey: pkg.pkgId, // coincide con el prop `pkgKey` de ReservarPaquete
+          sessions: 1, // siempre 1 sesión
           priceId: pkg.priceId,
         },
       },

--- a/src/lib/packages.ts
+++ b/src/lib/packages.ts
@@ -101,7 +101,7 @@ export const paquetes: PackageDef[] = [
     price: 2250,
     description: "Dos sesiones semanales 👶 en piso.",
     image: "/images/estimulacion_piso_animado.jpeg",
-    priceId: "price_1RMBIaFV5ZpZiouC8l6QjW2N",
+    priceId: "price_1RP6SsFV5ZpZiouCtbg4A7OE",
     category: "piso",
   },
   {


### PR DESCRIPTION
## Summary
- pass `priceId` to the checkout API instead of `lineItems`
- correct Stripe price IDs for the 8-session floor package
- clean up seed data for the same package
- fix dashboard navigation when buying or scheduling packages

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683a7de207088332a2d1665cb7044be2