### PR TITLE
Fix admin dashboard routing and add role-based access

### DIFF
--- a/src/components/admin/AdminCalendar.tsx
+++ b/src/components/admin/AdminCalendar.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Calendar from "react-calendar";
+import "react-calendar/dist/Calendar.css";
+import { Form, Button, Alert, ListGroup } from "react-bootstrap";
+
+interface Reservation {
+  id: string;
+  date: string;
+  therapistName: string;
+  userName: string;
+  serviceName: string;
+}
+
+export default function AdminCalendar() {
+  const [date, setDate] = useState<Date>(new Date());
+  const [reservations, setReservations] = useState<Reservation[]>([]);
+  const [userEmail, setUserEmail] = useState("");
+  const [serviceId, setServiceId] = useState("");
+  const [therapistId, setTherapistId] = useState("");
+  const [hour, setHour] = useState<number | null>(null);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState("");
+
+  useEffect(() => {
+    const start = new Date(date);
+    start.setHours(0, 0, 0, 0);
+    const end = new Date(date);
+    end.setHours(23, 59, 59, 999);
+    fetch(`/api/admin/reservations?start=${start.toISOString()}&end=${end.toISOString()}`)
+      .then((r) => r.json())
+      .then((data: Reservation[]) => setReservations(data))
+      .catch(console.error);
+  }, [date]);
+
+  const availableHours = [9,10,11,12,13,14,15,16,17,18];
+
+  const createReservation = async () => {
+    if (!userEmail || !serviceId || !therapistId || hour === null) {
+      setError("Faltan campos");
+      return;
+    }
+    const when = new Date(date);
+    when.setHours(hour, 0, 0, 0);
+    const res = await fetch("/api/admin/reservations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        userId: userEmail,
+        serviceId,
+        therapistId,
+        date: when.toISOString(),
+        paymentMethod: "efectivo",
+      }),
+    });
+    if (res.ok) {
+      setSuccess("Cita registrada");
+      setUserEmail("");
+      setServiceId("");
+      setTherapistId("");
+      setHour(null);
+    } else {
+      const data = await res.json();
+      setError(data.error || "Error");
+    }
+  };
+
+  return (
+    <div>
+      <h3 className="mb-3">Calendario</h3>
+      <Calendar value={date} onChange={(d) => setDate(Array.isArray(d) ? d[0] : d)} />
+      <ListGroup className="my-3">
+        {reservations.map((r) => (
+          <ListGroup.Item key={r.id}>
+            {new Date(r.date).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+            {" - "}{r.userName} ({r.serviceName})
+          </ListGroup.Item>
+        ))}
+      </ListGroup>
+      <h4>Registrar cita manual</h4>
+      {error && <Alert variant="danger">{error}</Alert>}
+      {success && <Alert variant="success">{success}</Alert>}
+      <Form className="mb-3">
+        <Form.Group className="mb-2">
+          <Form.Label>Correo del cliente (ID)</Form.Label>
+          <Form.Control value={userEmail} onChange={(e) => setUserEmail(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>ID del servicio</Form.Label>
+          <Form.Control value={serviceId} onChange={(e) => setServiceId(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>ID del terapeuta</Form.Label>
+          <Form.Control value={therapistId} onChange={(e) => setTherapistId(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>Hora</Form.Label>
+          <div>
+            {availableHours.map((h) => (
+              <Button
+                key={h}
+                className="me-1 mb-1"
+                variant={hour === h ? "primary" : "outline-primary"}
+                onClick={() => setHour(h)}
+              >
+                {h}:00
+              </Button>
+            ))}
+          </div>
+        </Form.Group>
+        <Button className="btn-orange" type="button" onClick={createReservation}>
+          Guardar
+        </Button>
+      </Form>
+    </div>
+  );
+}

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import Navbar from "../Navbar";
+import Footer from "../Footer";
+import { Container, Row, Col, Nav } from "react-bootstrap";
+import AdminCalendar from "./AdminCalendar";
+
+export default function AdminLayout() {
+  const [section, setSection] = useState("reservations");
+
+  const sections: { key: string; label: string }[] = [
+    { key: "clients", label: "Clientes" },
+    { key: "therapists", label: "Terapeutas" },
+    { key: "reservations", label: "Reservaciones" },
+    { key: "reports", label: "Reportes" },
+  ];
+
+  function renderContent() {
+    if (section === "reservations") return <AdminCalendar />;
+    return <p>Sección {section}</p>;
+  }
+
+  return (
+    <>
+      <Navbar />
+      <Container fluid className="py-4">
+        <Row>
+          <Col md={2} className="mb-3">
+            <Nav className="flex-column">
+              {sections.map((s) => (
+                <Nav.Link
+                  key={s.key}
+                  active={section === s.key}
+                  onClick={() => setSection(s.key)}
+                >
+                  {s.label}
+                </Nav.Link>
+              ))}
+            </Nav>
+          </Col>
+          <Col md={10}>{renderContent()}</Col>
+        </Row>
+      </Container>
+      <Footer />
+    </>
+  );
+}

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,23 @@
+import { GetServerSideProps } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../api/auth/[...nextauth]";
+import AdminLayout from "@/components/admin/AdminLayout";
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  if (!session) {
+    return {
+      redirect: { destination: "/login", permanent: false },
+    };
+  }
+  if (session.user.role !== "ADMIN") {
+    return {
+      redirect: { destination: "/dashboard", permanent: false },
+    };
+  }
+  return { props: {} };
+};
+
+export default function AdminPage() {
+  return <AdminLayout />;
+}

--- a/src/pages/api/auth/[...nextauth].ts
+++ b/src/pages/api/auth/[...nextauth].ts
@@ -27,11 +27,19 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async jwt({ token, user }) {
-      if (user) token.id = user.id;
+      if (user) {
+        token.id = user.id;
+        // include role in JWT token
+        token.role = (user as any).role;
+      }
       return token;
     },
     async session({ session, token }) {
-      if (session.user) session.user.id = token.id as string;
+      if (session.user) {
+        session.user.id = token.id as string;
+        // expose role in session
+        (session.user as any).role = token.role as string;
+      }
       return session;
     }
   },

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,6 +1,9 @@
 // File: src/components/DashboardLayout.tsx
 import Head from "next/head";
 import DashboardLayout from "@/components/DashboardLayout";
+import { GetServerSideProps } from "next";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "../api/auth/[...nextauth]";
 
 export default function DashboardPage() {
   return (
@@ -12,3 +15,14 @@ export default function DashboardPage() {
     </>
   );
 }
+
+export const getServerSideProps: GetServerSideProps = async (ctx) => {
+  const session = await getServerSession(ctx.req, ctx.res, authOptions);
+  if (!session) {
+    return { redirect: { destination: "/login", permanent: false } };
+  }
+  if (session.user.role === "ADMIN") {
+    return { redirect: { destination: "/admin", permanent: false } };
+  }
+  return { props: {} };
+};

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,6 @@
 // src/pages/login.tsx
 import { useState }              from "react";
-import { signIn }                 from "next-auth/react";
+import { signIn, getSession }     from "next-auth/react";
 import Head                       from "next/head";
 import Image                      from "next/image";
 import Link                       from "next/link";
@@ -20,18 +20,19 @@ export default function LoginPage() {
       redirect: false,
       email,
       password,
-      callbackUrl: `${window.location.origin}/dashboard?tab=reservar`,
     });
 
     setLoading(false);
 
     if (res?.error) {
       setError(res.error);
-    } else if (res?.url) {
-      // aquí forzamos la navegación definitiva
-      window.location.href = res.url;
     } else {
-      setError("Ocurrió un error inesperado");
+      const session = await getSession();
+      const target =
+        session?.user?.role === "ADMIN"
+          ? "/admin"
+          : "/dashboard?tab=reservar";
+      window.location.href = target;
     }
   };
 

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,16 +5,19 @@ declare module "next-auth" {
   interface Session extends DefaultSession {
     user: {
       id: string;
+      role: string;
     } & DefaultSession["user"];
   }
 
   interface User extends DefaultUser {
     id: string;
+    role: string;
   }
 }
 
 declare module "next-auth/jwt" {
   interface JWT {
     id: string;
+    role: string;
   }
 }


### PR DESCRIPTION
## Summary
- include user role in NextAuth session and JWT
- extend next-auth types with role field
- redirect admin users away from /dashboard
- add Admin dashboard page with sidebar and calendar
- update login flow to send admins to /admin

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e00c6df048332995e2e8122594a8f