### PR TITLE
Improve admin layout and login feedback

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  swcMinify: true,
+  devIndicators: false,
 };
 export default nextConfig;

--- a/src/components/admin/AdminLayout.tsx
+++ b/src/components/admin/AdminLayout.tsx
@@ -9,21 +9,24 @@ import {
   FaUsers,
   FaUserMd,
   FaCalendarAlt,
+  FaCalendarPlus,
   FaChartBar,
   FaCog,
 } from "react-icons/fa";
-import AdminCalendar from "./AdminCalendar";
+import CalendarSection from "./CalendarSection";
+import ManualReservationSection from "./ManualReservationSection";
 import ClientsSection from "./ClientsSection";
 import TherapistsSection from "./TherapistsSection";
 
 export default function AdminLayout() {
-  const [section, setSection] = useState("reservations");
+  const [section, setSection] = useState("manual");
   const { data: session } = useSession();
 
   const sections: { key: string; label: string; icon: JSX.Element }[] = [
     { key: "clients", label: "Clientes", icon: <FaUsers className="me-2" /> },
     { key: "therapists", label: "Terapeutas", icon: <FaUserMd className="me-2" /> },
-    { key: "reservations", label: "Reservaciones", icon: <FaCalendarAlt className="me-2" /> },
+    { key: "manual", label: "Generar reservación", icon: <FaCalendarPlus className="me-2" /> },
+    { key: "calendar", label: "Calendario", icon: <FaCalendarAlt className="me-2" /> },
     { key: "reports", label: "Reportes", icon: <FaChartBar className="me-2" /> },
     { key: "settings", label: "Configuración", icon: <FaCog className="me-2" /> },
   ];
@@ -34,8 +37,10 @@ export default function AdminLayout() {
         return <ClientsSection />;
       case "therapists":
         return <TherapistsSection />;
-      case "reservations":
-        return <AdminCalendar />;
+      case "manual":
+        return <ManualReservationSection />;
+      case "calendar":
+        return <CalendarSection />;
       case "reports":
         return <p>Reportes</p>;
       default:

--- a/src/components/admin/CalendarSection.tsx
+++ b/src/components/admin/CalendarSection.tsx
@@ -13,7 +13,7 @@ interface Reservation {
   serviceName: string;
 }
 
-export default function AdminCalendar() {
+export default function CalendarSection() {
   const [date, setDate] = useState<Date>(new Date());
   const [reservations, setReservations] = useState<Reservation[]>([]);
   const [userEmail, setUserEmail] = useState("");

--- a/src/components/admin/ManualReservationSection.tsx
+++ b/src/components/admin/ManualReservationSection.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useState } from "react";
+import { Form, Button, Alert } from "react-bootstrap";
+
+export default function ManualReservationSection() {
+  const [client, setClient] = useState("");
+  const [service, setService] = useState("");
+  const [therapist, setTherapist] = useState("");
+  const [date, setDate] = useState("");
+  const [time, setTime] = useState("");
+  const [message, setMessage] = useState<string|null>(null);
+  const [error, setError] = useState<string|null>(null);
+
+  const save = async () => {
+    setError(null);
+    setMessage(null);
+    const res = await fetch("/api/admin/reservations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        userId: client,
+        serviceId: service,
+        therapistId: therapist,
+        date: new Date(`${date}T${time}:00`).toISOString(),
+        paymentMethod: "efectivo",
+      }),
+    });
+    if (res.ok) {
+      setMessage("Reservación creada correctamente.");
+      setClient("");
+      setService("");
+      setTherapist("");
+      setDate("");
+      setTime("");
+    } else {
+      const data = await res.json();
+      setError(data.error || "Error");
+    }
+  };
+
+  return (
+    <div>
+      <h3 className="mb-3">Generar reservación</h3>
+      {message && <Alert variant="success">{message}</Alert>}
+      {error && <Alert variant="danger">{error}</Alert>}
+      <Form>
+        <Form.Group className="mb-2">
+          <Form.Label>Cliente</Form.Label>
+          <Form.Control value={client} onChange={e => setClient(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>Servicio</Form.Label>
+          <Form.Control value={service} onChange={e => setService(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>Terapeuta</Form.Label>
+          <Form.Control value={therapist} onChange={e => setTherapist(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-2">
+          <Form.Label>Fecha</Form.Label>
+          <Form.Control type="date" value={date} onChange={e => setDate(e.target.value)} />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label>Hora</Form.Label>
+          <Form.Control type="time" value={time} onChange={e => setTime(e.target.value)} />
+        </Form.Group>
+        <Button className="btn-orange" type="button" onClick={save}>Guardar</Button>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -14,15 +14,17 @@ export default function MyApp({
 }: AppProps) {
   const pathname = usePathname() || ''
 
-  // Tratamos /dashboard/* y /success como “rutas de Dashboard”:
-  const isDashboard =
+  // Tratamos /dashboard/*, /admin/* y /success como rutas con layout propio
+  const isDashboardOrAdmin =
     pathname === '/dashboard' ||
     pathname.startsWith('/dashboard/') ||
-    pathname === '/success'
+    pathname === '/success' ||
+    pathname === '/admin' ||
+    pathname.startsWith('/admin/')
 
   return (
     <SessionProvider session={session}>
-      {isDashboard ? (
+      {isDashboardOrAdmin ? (
         // El componente se encarga de su propio Navbar/Footer
         <Component {...pageProps} />
       ) : (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -25,7 +25,11 @@ export default function LoginPage() {
     setLoading(false);
 
     if (res?.error) {
-      setError(res.error);
+      const msg =
+        res.error === 'CredentialsSignin'
+          ? 'Error: correo o contraseña incorrectos.'
+          : res.error;
+      setError(msg);
     } else {
       const session = await getSession();
       const target =


### PR DESCRIPTION
## Summary
- provide friendlier login error messages
- avoid duplicate navbar/footer for admin pages
- update admin layout with sidebar items for manual reservations and calendar
- add placeholder manual reservation form
- rename AdminCalendar to CalendarSection
- update Next.js config

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683faf91311c8332a037c17e6470c268