### PR TITLE
Fix authOptions path in admin report export

### DIFF
--- a/src/pages/api/admin/reports/export.ts
+++ b/src/pages/api/admin/reports/export.ts
@@ -1,6 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { getServerSession } from "next-auth/next";
-import { authOptions } from "../auth/[...nextauth]";
+import { authOptions } from "../../auth/[...nextauth]";
 import prisma from "@/lib/prisma";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {


### PR DESCRIPTION
## Summary
- fix relative import to `[...nextauth]` in `src/pages/api/admin/reports/export.ts`

## Testing
- `npm run generate` *(fails: prisma not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684093e8d28c8332875a26f40ef90910