### PR TITLE
Fix reservation history data selects

### DIFF
--- a/src/components/dashboard/HistorySection.tsx
+++ b/src/components/dashboard/HistorySection.tsx
@@ -17,9 +17,9 @@ import { FaEdit, FaTrash, FaCalendarPlus } from "react-icons/fa";
 
 interface HistoryItem {
   id: string;
-  date: string;        // ISO string
-  serviceName: string; // viene de tu API (/api/appointments/history)
-  therapistName: string;
+  date: string; // ISO string
+  serviceName: string | null;
+  therapistName: string | null;
 }
 
 export default function HistorySection() {
@@ -81,10 +81,10 @@ export default function HistorySection() {
     const fmt = (x: Date) => x.toISOString().replace(/[-:]|\.\d{3}/g, "");
     return (
       "https://www.google.com/calendar/render?action=TEMPLATE" +
-      `&text=${encodeURIComponent(item.serviceName)}` +
+      `&text=${encodeURIComponent(item.serviceName ?? "Reserva")}` +
       `&dates=${fmt(start)}/${fmt(end)}` +
-      `&details=${encodeURIComponent(item.serviceName)}` +
-      `&location=${encodeURIComponent(item.serviceName)}`
+      `&details=${encodeURIComponent(item.serviceName ?? "")}` +
+      `&location=${encodeURIComponent(item.serviceName ?? "")}`
     );
   };
 
@@ -119,8 +119,8 @@ export default function HistorySection() {
               )}`;
               return (
                 <tr key={r.id}>
-                  <td>{r.serviceName}</td>
-                  <td>{r.therapistName}</td>
+                  <td>{r.serviceName ?? "—"}</td>
+                  <td>{r.therapistName ?? "—"}</td>
                   <td>{display}</td>
                   <td>
                     <OverlayTrigger

--- a/src/pages/api/admin/payments-report.ts
+++ b/src/pages/api/admin/payments-report.ts
@@ -30,7 +30,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       paidAt: { not: null },
       date: { gte: startDate, lte: endDate },
     },
-    include: { user: true, therapist: true },
+    select: {
+      id:            true,
+      date:          true,
+      paymentMethod: true,
+      user:       { select: { name: true } },
+      therapist:  { include: { user: { select: { name: true } } } },
+    },
     orderBy: { date: "asc" },
   });
 
@@ -47,7 +53,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     id: t.id,
     date: t.date.toISOString(),
     userName: t.user.name,
-    therapistName: t.therapist.name,
+    therapistName: t.therapist?.user?.name ?? "—",
     amount: 0,
     paymentMethod: t.paymentMethod,
   }));

--- a/src/pages/api/admin/reports/export.ts
+++ b/src/pages/api/admin/reports/export.ts
@@ -18,13 +18,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   const rows = await prisma.reservation.findMany({
     where: { date: { gte: fromDate, lte: toDate } },
-    include: { user: true, service: true, therapist: true },
+    select: {
+      date:          true,
+      paymentMethod: true,
+      user:      { select: { name: true } },
+      service:   { select: { name: true } },
+      therapist: { include: { user: { select: { name: true } } } },
+    },
     orderBy: { date: "asc" },
   });
 
   let csv = "Fecha,Cliente,Servicio,Terapeuta,Monto,Metodo\n";
   for (const r of rows) {
-    csv += `${r.date.toISOString()},${r.user.name},${r.service.name},${r.therapist.name},0,${r.paymentMethod}\n`;
+    csv += `${r.date.toISOString()},${r.user.name},${r.service.name},${r.therapist?.user?.name ?? "—"},0,${r.paymentMethod}\n`;
   }
 
   res.setHeader("Content-Type", "text/csv");

--- a/src/pages/api/admin/reservations.ts
+++ b/src/pages/api/admin/reservations.ts
@@ -10,8 +10,8 @@ export interface Reservation {
   id: string;
   date: string;
   userName: string;
-  serviceName: string;
-  therapistName: string;
+  serviceName: string | null;
+  therapistName: string | null;
   paymentMethod: string;
   sessionNumber: number;
   totalSessions: number;
@@ -38,7 +38,9 @@ export default async function handler(
   }
 
   const { start, end, date } = req.query as {
-    start?: string; end?: string; date?: string;
+    start?: string;
+    end?: string;
+    date?: string;
   };
 
   // GET rango completo (calendario)
@@ -50,7 +52,11 @@ export default async function handler(
         date: { gte: from, lte: to },
         NOT:  { userPackageId: null },
       },
-      include: {
+      select: {
+        id:            true,
+        date:          true,
+        paymentMethod: true,
+        userPackageId: true,
         user:       { select: { name: true } },
         service:    { select: { name: true } },
         therapist:  { include: { user: { select: { name: true } } } },
@@ -76,8 +82,8 @@ export default async function handler(
           id:            r.id,
           date:          r.date.toISOString(),
           userName:      r.user.name ?? "—",
-          serviceName:   r.service.name,
-          therapistName: r.therapist.user.name ?? "—",  // <-- aquí también
+          serviceName:   r.service?.name ?? null,
+          therapistName: r.therapist?.user?.name ?? null,
           paymentMethod: r.paymentMethod,
           sessionNumber: idx + 1,
           totalSessions: total,
@@ -146,8 +152,8 @@ export default async function handler(
         id:            r.id,
         date:          r.date.toISOString(),
         userName:      me.name  ?? "—",
-        serviceName:   "", // el front re-fetchea para mostrar todo
-        therapistName: "", 
+        serviceName:   null,
+        therapistName: null,
         paymentMethod: r.paymentMethod,
         sessionNumber: 0,
         totalSessions: 0,

--- a/src/pages/api/appointments/history.ts
+++ b/src/pages/api/appointments/history.ts
@@ -7,8 +7,9 @@ import prisma                                 from "@/lib/prisma";
 export interface HistoryItem {
   id: string;
   date: string;
-  serviceName: string;
-  therapistName: string;
+  serviceName: string | null;
+  therapistName: string | null;
+  userPackageId: string | null;
 }
 
 export default async function handler(
@@ -29,7 +30,10 @@ export default async function handler(
 
   const reservations = await prisma.reservation.findMany({
     where: { userId: session.user.id },
-    include: {
+    select: {
+      id:            true,
+      date:          true,
+      userPackageId: true,
       service:   { select: { name: true } },
       therapist: { include: { user: { select: { name: true } } } },
     },
@@ -39,8 +43,9 @@ export default async function handler(
   const data: HistoryItem[] = reservations.map((r) => ({
     id:            r.id,
     date:          r.date.toISOString(),
-    serviceName:   r.service.name,
-    therapistName: r.therapist.user.name ?? "—",   // <-- aquí aseguramos string
+    serviceName:   r.service?.name ?? null,
+    therapistName: r.therapist?.user?.name ?? null,
+    userPackageId: r.userPackageId,
   }));
 
   await prisma.$disconnect();

--- a/src/pages/api/appointments/index.ts
+++ b/src/pages/api/appointments/index.ts
@@ -13,15 +13,20 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   if (req.method === "GET") {
     const reservations = await prisma.reservation.findMany({
       where: { userId: session.user.id },
-      include: { service: true, therapist: true },
+      select: {
+        id:   true,
+        date: true,
+        service:   { select: { name: true } },
+        therapist: { include: { user: { select: { name: true } } } },
+      },
       orderBy: { date: "desc" },
     });
 
     const mapped = reservations.map((r) => ({
       id: r.id,
       date: r.date.toISOString(),
-      serviceName: r.service.name,        // ✅ Correcto
-      therapistName: r.therapist.name,    // ✅ Correcto
+      serviceName: r.service?.name ?? null,
+      therapistName: r.therapist?.user?.name ?? null,
     }));
 
     const ok = res.status(200).json({ reservations: mapped });


### PR DESCRIPTION
## Summary
- fix includes/selects in appointment history API
- adjust admin reservations data selection and make names nullable
- allow nullable values in dashboard HistorySection component
- include therapist's user name in payment and export reports
- update appointments API selects
- clarify history item types

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_68546ffa0b348332ba289063f222d562