### PR TITLE
Integrar FRONT‑B1/B2/B3: Reservas admin, Dashboard analytics y Stripe Connect

### DIFF
--- a/apps/web/src/app/(app)/admin/reservations-management/page.tsx
+++ b/apps/web/src/app/(app)/admin/reservations-management/page.tsx
@@ -1,47 +1,98 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { format } from 'date-fns';
 import { FiltersBar } from '../../../components/FiltersBar';
 import { DataTable, type Column } from '../../../components/DataTable';
+import { getReservations, type Reservation as ApiReservation } from '@/lib/admin-api';
 
-interface Reservation {
+type ReservationStatus = 'pending' | 'confirmed' | 'completed' | 'cancelled' | 'no_show';
+
+interface ReservationRow {
   id: string;
   date: string;
   time: string;
   client: string;
   service: string;
   therapist: string;
-  status: 'pending' | 'confirmed' | 'completed' | 'cancelled';
+  status: ReservationStatus;
   amount: number;
 }
 
-// Mock data
-const mockReservations: Reservation[] = [
-  { id: 'RES-001', date: '2025-11-30', time: '09:00', client: 'María González', service: 'Fisioterapia', therapist: 'Dr. Pérez', status: 'confirmed', amount: 500 },
-  { id: 'RES-002', date: '2025-11-30', time: '10:00', client: 'Juan Martínez', service: 'Masajes', therapist: 'Ana López', status: 'completed', amount: 450 },
-  { id: 'RES-003', date: '2025-11-30', time: '11:00', client: 'Pedro Sánchez', service: 'Quiropráctica', therapist: 'Dr. Ramírez', status: 'pending', amount: 600 },
-  { id: 'RES-004', date: '2025-11-30', time: '14:00', client: 'Laura Jiménez', service: 'Hidroterapia', therapist: 'Carla Torres', status: 'confirmed', amount: 700 },
-  { id: 'RES-005', date: '2025-11-30', time: '15:30', client: 'Carlos Ruiz', service: 'Fisioterapia', therapist: 'Dr. Pérez', status: 'cancelled', amount: 500 },
-];
-
-const statusColors = {
+const statusColors: Record<ReservationStatus, { bg: string; border: string; text: string }> = {
   pending: { bg: 'rgba(251, 191, 36, 0.2)', border: 'rgba(251, 191, 36, 0.4)', text: '#fbbf24' },
   confirmed: { bg: 'rgba(96, 186, 194, 0.2)', border: 'rgba(96, 186, 194, 0.4)', text: '#60bac2' },
   completed: { bg: 'rgba(34, 197, 94, 0.2)', border: 'rgba(34, 197, 94, 0.4)', text: '#22c55e' },
   cancelled: { bg: 'rgba(239, 68, 68, 0.2)', border: 'rgba(239, 68, 68, 0.4)', text: '#ef4444' },
+  no_show: { bg: 'rgba(148, 163, 184, 0.2)', border: 'rgba(148, 163, 184, 0.4)', text: '#94a3b8' },
 };
 
-const statusLabels = {
+const statusLabels: Record<ReservationStatus, string> = {
   pending: 'Pendiente',
   confirmed: 'Confirmada',
   completed: 'Completada',
   cancelled: 'Cancelada',
+  no_show: 'No show',
 };
 
 export default function ReservationsManagementPage() {
-  const [filteredData, setFilteredData] = useState(mockReservations);
+  const searchParams = useSearchParams();
+  const searchTerm = searchParams.get('search')?.trim() ?? '';
+  const [page, setPage] = useState(1);
+  const [filters, setFilters] = useState<{ status?: string; service?: string }>({});
+  const pageSize = 20;
 
-  const columns: Column<Reservation>[] = [
+  const statusFilter = filters.status?.toUpperCase();
+
+  const { data: reservations = [], isLoading, error } = useQuery({
+    queryKey: ['admin-reservations', page, pageSize, statusFilter],
+    queryFn: () => getReservations({
+      page,
+      pageSize,
+      status: statusFilter || undefined,
+    }),
+  });
+
+  useEffect(() => {
+    setPage(1);
+  }, [searchTerm]);
+
+  const rows = useMemo(() => (
+    reservations.map((reservation: ApiReservation): ReservationRow => {
+      const dateValue = reservation.startAt ?? reservation.createdAt;
+      const startAt = dateValue ? new Date(dateValue) : null;
+      const status = reservation.status?.toLowerCase() as ReservationStatus;
+      return {
+        id: reservation.id,
+        date: dateValue,
+        time: startAt ? format(startAt, 'HH:mm') : '--:--',
+        client: reservation.user?.name || reservation.user?.email || 'Sin cliente',
+        service: reservation.service?.name || 'Sin servicio',
+        therapist: reservation.therapist?.name || 'Sin terapeuta',
+        status: status || 'pending',
+        amount: reservation.service?.price ?? 0,
+      };
+    })
+  ), [reservations]);
+
+  const filteredData = useMemo(() => {
+    const normalizedSearch = searchTerm.toLowerCase();
+    const serviceFilter = filters.service?.toLowerCase();
+    return rows.filter((row) => {
+      if (serviceFilter && !row.service.toLowerCase().includes(serviceFilter)) {
+        return false;
+      }
+      if (normalizedSearch) {
+        const haystack = `${row.client} ${row.service} ${row.therapist}`.toLowerCase();
+        return haystack.includes(normalizedSearch);
+      }
+      return true;
+    });
+  }, [rows, searchTerm, filters.service]);
+
+  const columns: Column<ReservationRow>[] = [
     {
       key: 'id',
       header: 'ID',
@@ -79,8 +130,8 @@ export default function ReservationsManagementPage() {
       header: 'Estado',
       width: '130px',
       sortable: true,
-      render: (value: Reservation['status']) => {
-        const colors = statusColors[value];
+      render: (value: ReservationRow['status']) => {
+        const colors = statusColors[value] || statusColors.pending;
         return (
           <span style={{
             padding: '0.375rem 0.75rem',
@@ -102,11 +153,11 @@ export default function ReservationsManagementPage() {
       header: 'Monto',
       width: '100px',
       sortable: true,
-      render: (value) => `$${value}`,
+      render: (value) => `$${value.toLocaleString('es-MX')}`,
     },
   ];
 
-  const filters = [
+  const filterOptions = [
     {
       key: 'status',
       label: 'Estado',
@@ -130,20 +181,15 @@ export default function ReservationsManagementPage() {
   ];
 
   const handleFilterChange = (filters: Record<string, string | string[]>) => {
-    let filtered = [...mockReservations];
-    
-    if (filters.status) {
-      filtered = filtered.filter(r => r.status === filters.status);
-    }
-    
-    if (filters.service) {
-      filtered = filtered.filter(r => 
-        r.service.toLowerCase().includes((filters.service as string).toLowerCase())
-      );
-    }
-    
-    setFilteredData(filtered);
+    setFilters({
+      status: typeof filters.status === 'string' ? filters.status : undefined,
+      service: typeof filters.service === 'string' ? filters.service : undefined,
+    });
+    setPage(1);
   };
+
+  const canGoBack = page > 1;
+  const canGoForward = reservations.length === pageSize;
 
   return (
     <div style={{ padding: '2rem' }}>
@@ -157,16 +203,52 @@ export default function ReservationsManagementPage() {
       </div>
 
       <FiltersBar 
-        filters={filters} 
+        filters={filterOptions} 
         onFilterChange={handleFilterChange}
       />
+
+      {error && (
+        <div className="glass-panel" style={{ padding: '1.5rem', marginBottom: '1.5rem' }}>
+          <div style={{ color: 'var(--color-text-secondary)' }}>
+            ⚠️ No pudimos cargar las reservas. Intenta nuevamente en unos minutos.
+          </div>
+        </div>
+      )}
 
       <DataTable
         data={filteredData}
         columns={columns}
         rowKey="id"
+        loading={isLoading}
+        emptyMessage="No hay reservas para los filtros seleccionados"
         onRowClick={(row) => console.log('Clicked:', row)}
       />
+
+      <div className="glass-panel" style={{ marginTop: '1.5rem', padding: '1rem 1.5rem', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span style={{ color: 'var(--color-text-secondary)', fontSize: '0.875rem' }}>
+          Página {page}
+        </span>
+        <div style={{ display: 'flex', gap: '0.75rem' }}>
+          <button
+            type="button"
+            className="bloom-button"
+            style={{ padding: '0.5rem 1rem', opacity: canGoBack ? 1 : 0.5 }}
+            onClick={() => canGoBack && setPage((prev) => prev - 1)}
+            disabled={!canGoBack || isLoading}
+          >
+            ← Anterior
+          </button>
+          <button
+            type="button"
+            className="bloom-button"
+            style={{ padding: '0.5rem 1rem', opacity: canGoForward ? 1 : 0.5 }}
+            onClick={() => canGoForward && setPage((prev) => prev + 1)}
+            disabled={!canGoForward || isLoading}
+          >
+            Siguiente →
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/components/dashboard/Charts.tsx
+++ b/apps/web/src/app/components/dashboard/Charts.tsx
@@ -9,9 +9,10 @@ interface ReservationsChartProps {
     completed: number;
     cancelled: number;
   }>;
+  subtitle?: string;
 }
 
-export function ReservationsChart({ data }: ReservationsChartProps) {
+export function ReservationsChart({ data, subtitle }: ReservationsChartProps) {
   return (
     <div className="glass-panel" style={{ padding: '1.5rem' }}>
       <div style={{ marginBottom: '1.5rem' }}>
@@ -19,7 +20,7 @@ export function ReservationsChart({ data }: ReservationsChartProps) {
           Reservas por día
         </h3>
         <p style={{ fontSize: '0.875rem', color: 'var(--color-text-secondary)' }}>
-          Últimos 7 días
+          {subtitle ?? 'Últimos 7 días'}
         </p>
       </div>
 
@@ -86,9 +87,10 @@ interface RevenueChartProps {
     pos: number;
     cash: number;
   }>;
+  subtitle?: string;
 }
 
-export function RevenueChart({ data }: RevenueChartProps) {
+export function RevenueChart({ data, subtitle }: RevenueChartProps) {
   return (
     <div className="glass-panel" style={{ padding: '1.5rem' }}>
       <div style={{ marginBottom: '1.5rem' }}>
@@ -96,7 +98,7 @@ export function RevenueChart({ data }: RevenueChartProps) {
           Ingresos por método de pago
         </h3>
         <p style={{ fontSize: '0.875rem', color: 'var(--color-text-secondary)' }}>
-          Últimas 4 semanas
+          {subtitle ?? 'Últimas 4 semanas'}
         </p>
       </div>
 

--- a/apps/web/src/lib/admin-api.ts
+++ b/apps/web/src/lib/admin-api.ts
@@ -41,8 +41,38 @@ export type DashboardOverviewResponse = {
   fallback?: boolean;
 };
 
+export type ReservationsAnalyticsPoint = {
+  date: string;
+  reservations: number;
+  completed: number;
+  cancelled: number;
+};
+
+export type RevenueAnalyticsPoint = {
+  period: string;
+  stripe: number;
+  pos: number;
+  cash: number;
+};
+
 export async function getDashboardOverview() {
   return apiFetch<DashboardOverviewResponse>("/api/v1/dashboard/overview");
+}
+
+export async function getReservationsAnalytics(params?: { start?: string; end?: string }) {
+  const searchParams = new URLSearchParams();
+  if (params?.start) searchParams.set("start", params.start);
+  if (params?.end) searchParams.set("end", params.end);
+  const query = searchParams.toString();
+  return apiFetch<ReservationsAnalyticsPoint[]>(`/api/v1/analytics/reservations${query ? `?${query}` : ""}`);
+}
+
+export async function getRevenueAnalytics(params?: { start?: string; end?: string }) {
+  const searchParams = new URLSearchParams();
+  if (params?.start) searchParams.set("start", params.start);
+  if (params?.end) searchParams.set("end", params.end);
+  const query = searchParams.toString();
+  return apiFetch<RevenueAnalyticsPoint[]>(`/api/v1/analytics/revenue${query ? `?${query}` : ""}`);
 }
 
 export async function getPosTickets() {
@@ -596,6 +626,9 @@ export type ConnectStatus = {
   chargesEnabled: boolean;
   payoutsEnabled: boolean;
   accountId?: string;
+  detailsSubmitted?: boolean;
+  requirementsDue?: string[];
+  disabledReason?: string | null;
 };
 
 export type ConnectOnboardingResponse = {
@@ -605,20 +638,38 @@ export type ConnectOnboardingResponse = {
 };
 
 export async function getConnectStatus() {
-  return apiFetch<ConnectStatus>("/api/v1/connect/status");
+  return apiFetch<ConnectStatus>("/api/v1/stripe/connect/status");
 }
 
 export async function startConnectOnboarding(refreshUrl: string, returnUrl: string) {
-  return apiFetch<ConnectOnboardingResponse>("/api/v1/connect/onboarding", {
+  return apiFetch<ConnectOnboardingResponse>("/api/v1/stripe/connect/onboarding", {
     method: "POST",
     json: { refreshUrl, returnUrl },
   });
 }
 
 export async function getStripeDashboardLink() {
-  return apiFetch<{ url: string }>("/api/v1/connect/dashboard-link", {
+  return apiFetch<{ url: string }>("/api/v1/stripe/connect/dashboard-link", {
     method: "POST",
   });
+}
+
+export type StripeWebhookEvent = {
+  id: string;
+  type: string;
+  createdAt: string;
+  status?: string;
+};
+
+export type StripeWebhookHealth = {
+  status: "healthy" | "degraded" | "missing" | "unknown";
+  lastEventAt?: string;
+  lastEventType?: string;
+  events?: StripeWebhookEvent[];
+};
+
+export async function getStripeWebhookHealth() {
+  return apiFetch<StripeWebhookHealth>("/api/v1/stripe/webhooks/health");
 }
 
 // ============================================

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -159,6 +159,30 @@ Existe `/dashboard-improved` con mock data para gráficas avanzadas (reservation
 
 ---
 
+## 2026-01-22 — Integración real para FRONT-B1, B2 y B3
+
+**Contexto:**  
+Las vistas de administración de reservas, dashboard mejorado y Stripe Connect dependían de mock data o estados incompletos, lo que impedía validar operaciones reales y monitorear pagos.
+
+**Decisiones:**
+1. **Reservas admin (FRONT-B1):** conectar `/admin/reservations-management` al API real con paginación básica, filtros conectados a query params y fallback local para búsqueda por texto/servicio.
+2. **Dashboard mejorado (FRONT-B2):** consumir endpoints de analytics con rango de fechas, mostrar estados de carga/empty/error y alinear subtítulos de charts al rango seleccionado.
+3. **Stripe Connect (FRONT-B3):** ampliar el status panel con requisitos pendientes y salud de webhooks, y reforzar el flujo de reintento de onboarding cuando hay bloqueos.
+
+**Consecuencias:**
+- Datos reales visibles sin esperar consolidación del backend del dashboard principal.
+- UX de pagos más transparente (estado, bloqueos y señales de webhooks).
+- Paginación y filtros listos para escalar volumen de reservas.
+
+**Archivos modificados:**
+- `apps/web/src/app/(app)/admin/reservations-management/page.tsx`
+- `apps/web/src/app/(app)/dashboard-improved/page.tsx`
+- `apps/web/src/app/components/dashboard/Charts.tsx`
+- `apps/web/src/app/(app)/settings/payments/page.tsx`
+- `apps/web/src/lib/admin-api.ts`
+
+---
+
 ## 2026-01-21 — Frontend RBAC Guardrails (UI + rutas)
 
 **Contexto:**  


### PR DESCRIPTION
### Motivation
- Completar las integraciones pendientes identificadas en la auditoría frontend para FRONT‑B1, FRONT‑B2 y FRONT‑B3 conectando UIs que usaban mock data a endpoints reales y mostrando estados operativos claros.
- Mejorar la visibilidad operativa de pagos añadiendo salud de webhooks y requisitos de Stripe para permitir detección y recuperación de onboarding incompleto.

### Description
- Conecté la página de administración de reservas a la API real usando `useQuery` y `getReservations`, normalicé la forma de mostrar filas, añadí paginación básica y enlacé los filtros de `FiltersBar` a la consulta; cambios en `apps/web/src/app/(app)/admin/reservations-management/page.tsx`.
- Añadí endpoints de analytics y tipos (`getReservationsAnalytics`, `getRevenueAnalytics`, `ReservationsAnalyticsPoint`, `RevenueAnalyticsPoint`) en `apps/web/src/lib/admin-api.ts` y consumí esos endpoints desde `apps/web/src/app/(app)/dashboard-improved/page.tsx`, incluyendo estados de carga/empty/error y subtítulos dinámicos para las gráficas.
- Extendí el panel de Stripe Connect para usar nuevos endpoints (`/api/v1/stripe/*`), mostrar `requirementsDue`, `detailsSubmitted` y la salud de webhooks (`getStripeWebhookHealth`) con resumen de eventos y badges, y mejoré textos de reintento de onboarding en `apps/web/src/app/(app)/settings/payments/page.tsx`.
- Hice pequeñas mejoras en los componentes de presentación: `apps/web/src/app/components/dashboard/Charts.tsx` ahora acepta `subtitle`, y `DataTable`/`FiltersBar` se usan para estados de carga y mensajes vacíos.
- Documenté la decisión en `docs/DECISIONS.md` listando los cambios realizados para FRONT‑B1/B2/B3.

### Testing
- Levanté la app en modo desarrollo con `npm run dev --workspace web -H 0.0.0.0 -p 3000` y Next.js arrancó correctamente (local server listo), lo que valida que los cambios compilan en caliente.
- Intenté capturar una vista con Playwright (`/dashboard-improved`) pero el navegador headless Chromium falló con un crash (`TargetClosedError` / SIGSEGV), por lo que la captura automatizada no pudo completarse.
- No se ejecutaron pruebas unitarias automatizadas adicionales en este rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696ff13a236c833298673385b220fe11)